### PR TITLE
Implementa model e rotas para cargos de mesa

### DIFF
--- a/models/index.js
+++ b/models/index.js
@@ -29,6 +29,7 @@ const ligacoesEconomicasModel = './postgres/ligacoes-economicas.js';
 const empresasModel = './postgres/empresas.js';
 const empresasParlamentaresModel = './postgres/empresas-parlamentares.js';
 const atividadesEconomicasEmpresasModel = './postgres/atividades-economicas-empresas.js';
+const cargosMesaModel = './postgres/cargos-mesa.js';
 
 if (!global.hasOwnProperty("models")) {
   const db = require("../config/keys").postgresURI;
@@ -78,7 +79,8 @@ if (!global.hasOwnProperty("models")) {
     ligacoesEconomicas: sequelize.import(ligacoesEconomicasModel),
     empresas: sequelize.import(empresasModel),
     empresasParlamentares: sequelize.import(empresasParlamentaresModel),
-    atividadesEconomicasEmpresas: sequelize.import(atividadesEconomicasEmpresasModel)
+    atividadesEconomicasEmpresas: sequelize.import(atividadesEconomicasEmpresasModel),
+    cargosMesa: sequelize.import(cargosMesaModel)
     // add your other models here
   };
 

--- a/models/postgres/cargos-mesa.js
+++ b/models/postgres/cargos-mesa.js
@@ -7,10 +7,7 @@ module.exports = (sequelize, type) => {
         primaryKey: true
       },
       casa: type.STRING,
-      cargo: type.STRING,
-      data_inicio: type.DATE,
-      data_fim: type.DATE,
-      legislatura: type.INTEGER
+      cargo: type.STRING
     },
     {
       timestamps: false,

--- a/models/postgres/cargos-mesa.js
+++ b/models/postgres/cargos-mesa.js
@@ -1,0 +1,27 @@
+module.exports = (sequelize, type) => {
+  cargosMesa = sequelize.define(
+    "cargos_mesa",
+    {
+      id_parlamentar_voz: {
+        type: type.STRING,
+        primaryKey: true
+      },
+      casa: type.STRING,
+      cargo: type.STRING,
+      data_inicio: type.DATE,
+      data_fim: type.DATE,
+      legislatura: type.INTEGER
+    },
+    {
+      timestamps: false
+    }
+  );
+  cargosMesa.associate = function (models) {
+    cargosMesa.belongsTo(models.parlamentar, {
+      foreignKey: "id_parlamentar_voz",
+      sourceKey: "id_parlamentar_voz",
+      as: "cargosMesaParlamentar"
+    })
+  };
+  return cargosMesa;
+};

--- a/models/postgres/cargos-mesa.js
+++ b/models/postgres/cargos-mesa.js
@@ -13,7 +13,8 @@ module.exports = (sequelize, type) => {
       legislatura: type.INTEGER
     },
     {
-      timestamps: false
+      timestamps: false,
+      freezeTableName: true
     }
   );
   cargosMesa.associate = function (models) {

--- a/models/postgres/parlamentar.js
+++ b/models/postgres/parlamentar.js
@@ -74,6 +74,11 @@ module.exports = (sequelize, type) => {
         foreignKey: "id_parlamentar_voz",
         targetKey: "id_parlamentar_voz",      
         as: "parlamentarEmpresas"
+      }),
+      parlamentar.hasMany(models.cargosMesa, {
+        foreignKey: "id_parlamentar_voz",
+        targetKey: "id_parlamentar_voz",      
+        as: "parlamentarCargosMesa"
       })
     };
     return parlamentar;

--- a/models/postgres/parlamentar.js
+++ b/models/postgres/parlamentar.js
@@ -75,7 +75,7 @@ module.exports = (sequelize, type) => {
         targetKey: "id_parlamentar_voz",      
         as: "parlamentarEmpresas"
       }),
-      parlamentar.hasMany(models.cargosMesa, {
+      parlamentar.hasOne(models.cargosMesa, {
         foreignKey: "id_parlamentar_voz",
         targetKey: "id_parlamentar_voz",      
         as: "parlamentarCargosMesa"

--- a/routes/api/cargos-mesa.js
+++ b/routes/api/cargos-mesa.js
@@ -1,0 +1,43 @@
+const express = require("express");
+const Sequelize = require("sequelize");
+const { validationResult } = require('express-validator');
+
+const router = express.Router();
+
+const casaValidator = require("../../utils/middlewares/casa.validator");
+
+const models = require("../../models/index");
+const CargosMesa = models.cargosMesa;
+
+const BAD_REQUEST = 400;
+const SUCCESS = 200;
+
+
+/**
+ * Recupera cargos na Mesa Diretora
+ * @name get/api/cargos-mesa
+ * @function
+ * @apiparam Casa Casa de origem do parlamentar. Pode ser "camara" (default) ou "senado".
+ * @memberof module:routes/cargos-mesa
+ */
+router.get("/", casaValidator.validate, (req, res) => {
+
+  const errors = validationResult(req);
+
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+
+  const casa = req.param("casa") || "camara"
+
+  CargosMesa.findAll({
+    attributes: [[Sequelize.fn('DISTINCT', Sequelize.col('cargo')) ,'cargo']],
+    where: {
+      casa: casa
+    }
+  })
+  .then(cargosMesa => res.status(SUCCESS).json(cargosMesa))
+  .catch(err => res.status(BAD_REQUEST).json({ err }));
+});
+
+module.exports = router;

--- a/routes/api/parlamentares.js
+++ b/routes/api/parlamentares.js
@@ -1,7 +1,6 @@
 const express = require("express");
 const router = express.Router();
 const { validationResult } = require('express-validator');
-const Sequelize = require("sequelize");
 
 const models = require("../../models/index");
 const { formataVotacoes } = require("../../utils/functions");

--- a/routes/api/parlamentares.js
+++ b/routes/api/parlamentares.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const router = express.Router();
 const { validationResult } = require('express-validator');
+const Sequelize = require("sequelize");
 
 const models = require("../../models/index");
 const { formataVotacoes } = require("../../utils/functions");
@@ -14,6 +15,7 @@ const Comissoes = models.comissoes;
 const ComposicaoComissoes = models.composicaoComissoes;
 const Liderancas = models.liderancas;
 const Partido = models.partido;
+const CargosMesa = models.cargosMesa;
 
 const BAD_REQUEST = 400;
 const SUCCESS = 200;
@@ -357,6 +359,25 @@ router.get("/:id/liderancas", (req, res) => {
         }]
       }
     ],
+    where: { id_parlamentar_voz: req.params.id }
+  })
+    .then(parlamentar => {
+      return res.json(parlamentar);
+    })
+    .catch(err => res.status(BAD_REQUEST).json({ err: err.message }));
+});
+
+/**
+ * Recupera informações de cargos na Mesa Diretora para um parlamentar a partir de seu id (no Voz Ativa)
+ * @name get/api/parlamentares/:id/cargos-mesa
+ * @function
+ * @memberof module:routes/parlamentares
+ * @param {string} id - id do parlamentar na plataforma Voz Ativa
+ */
+router.get("/:id/cargos-mesa", (req, res) => {
+  CargosMesa.findOne({
+    attributes: [
+      ["id_parlamentar_voz", "idParlamentarVoz"], "cargo"],
     where: { id_parlamentar_voz: req.params.id }
   })
     .then(parlamentar => {

--- a/server.js
+++ b/server.js
@@ -22,6 +22,7 @@ const perfil = require("./routes/api/perfil");
 const investimentoPartidario = require("./routes/api/investimentoPartidario");
 const buscaParlamentar = require("./routes/api/busca-parlamentar");
 const votacoes = require("./routes/api/votacoes");
+const cargosMesa = require("./routes/api/cargos-mesa");
 
 const app = express();
 app.use(forceSsl);
@@ -68,6 +69,7 @@ app.use("/api/perfil", perfil);
 app.use("/api/investimento", investimentoPartidario);
 app.use("/api/busca-parlamentar", buscaParlamentar);
 app.use("/api/votacoes", votacoes);
+app.use("/api/cargos-mesa", cargosMesa);
 
 // Set static folder
 app.use(express.static("client/build"));


### PR DESCRIPTION
Este PR:
- Adiciona model cargos_mesa;
- Cria a rota '/api/cargos-mesa?casa=<casa>' que retorna os diferentes cargos de mesa diretora (default: camara);
- Cria a rota 'api/parlamentares/<id>/cargos-mesa' que retorna um objeto idParlamentar e cargo na mesa diretora.

Rodar com a branch `686-mover-arquivos-cargos-mesa` do [perfil-parlamentar-dados](https://github.com/parlametria/perfil-parlamentar-dados)