### PR TITLE
Adiciona endpoints para recuperar presidentes de comissões

### DIFF
--- a/server.js
+++ b/server.js
@@ -31,11 +31,18 @@ app.use(compression());
 var db = require("./server/models/index");
 
 const corsOptions = {
-  origin: ['http://localhost:4200', 'http://localhost:3000', 'https://front.dev.leggo.org.br', 'https://leggo.org.br'],
+  origin: [
+    'http://localhost:4200', 'http://localhost:3000',
+    'https://front.dev.leggo.org.br', 'https://leggo.org.br',
+    'https://leggo-painel.herokuapp.com',
+    'https://leggo-painel-validacao.herokuapp.com',
+    'https://leggo-painel.parlametria.org.br',
+    'https://painel.parlametria.org',
+    'https://painel.parlametria.org.br'],
   methods: "GET,HEAD,PUT,PATCH,POST,DELETE",
   credentials: true,
   allowedHeaders: ["Content-Type", "Authorization"],
-  exposedHeaders: ["authorization", ]
+  exposedHeaders: ["authorization"]
 };
 app.use(cors(corsOptions));
 

--- a/server/routes/api/comissoes.js
+++ b/server/routes/api/comissoes.js
@@ -187,7 +187,7 @@ router.get("/cargos", casaValidator.validate, (req, res) => {
 *  /api/presidentes/:
 *    get:
 *      summary: Recupera parlamentares presidentes em comissões da Câmara e do Senado.
-*      tags: [Parlamentar (comissões)]
+*      tags: [Comissões)]
 *      responses:
 *        "200":
 *          description: Recupera informações da lista de parlamentares presidentes de comissões.
@@ -214,6 +214,56 @@ router.get("/presidentes", (req, res) => {
         required: true
       }
     ]
+  })
+    .then(parlamentares => {
+      res.status(SUCCESS).json(parlamentares);
+    })
+    .catch(err => res.status(BAD_REQUEST).json({ err: err.message }));
+});
+
+/**
+* @swagger
+* path:
+*  /api/presidentes/{id}:
+*    get:
+*      summary: Recupera presidências em comissões de um parlamentar específico
+*      tags: [Comissões]
+*      parameters:
+*        - in: path
+*          name: id
+*          schema:
+*            type: integer
+*          required: true
+*          description: Id do parlamentar
+*      responses:
+*        "200":
+*          description: Recupera informações da lista de parlamentares presidentes de comissões.
+*/
+router.get("/presidentes/:id", (req, res) => {
+  Parlamentar.findAll({
+    attributes: ["id_parlamentar_voz", "casa"],
+    include: [
+      {
+        model: ComposicaoComissoes,
+        attributes: ["cargo"],
+        include: [
+          {
+            model: Comissoes,
+            attributes: ["sigla"],
+            as: "infoComissao",
+            required: false
+          }
+        ],
+        where: {
+          cargo: "Presidente"
+        },
+        as: "parlamentarComissoes",
+        required: true
+      }
+    ],
+    where: {
+      id_parlamentar_voz: req.params.id
+    }
   })
     .then(parlamentares => {
       res.status(SUCCESS).json(parlamentares);

--- a/server/routes/api/comissoes.js
+++ b/server/routes/api/comissoes.js
@@ -9,7 +9,10 @@ const casaValidator = require("../../utils/middlewares/casa.validator");
 const models = require("../../models/index");
 const Comissoes = models.comissoes;
 const ComposicaoComissoes = models.composicaoComissoes;
+const Parlamentar = models.parlamentar;
 
+const BAD_REQUEST = 400;
+const SUCCESS = 200;
 
 /**
 * @swagger
@@ -90,7 +93,7 @@ router.get("/composicao", casaValidator.validate, (req, res) => {
     include: [
       {
         attributes: [],
-        model: Comissoes,        
+        model: Comissoes,
         as: "infoComissao",
         required: true,
         where: {
@@ -160,22 +163,62 @@ router.get("/cargos", casaValidator.validate, (req, res) => {
   const casa = req.param("casa") || "camara"
 
   ComposicaoComissoes.findAll({
-    attributes: [[Sequelize.fn('DISTINCT', Sequelize.col('cargo')), 'cargo']],    
+    attributes: [[Sequelize.fn('DISTINCT', Sequelize.col('cargo')), 'cargo']],
     include: [
       {
         attributes: [],
-        model: Comissoes,        
+        model: Comissoes,
         as: "infoComissao",
         required: true,
         where: {
           casa: casa
         }
       }
-    ],    
+    ],
     raw: true
-  })  
+  })
     .then(composicao => res.status(200).json(composicao))
     .catch(err => res.status(400).json(err.message));
+});
+
+/**
+* @swagger
+* path:
+*  /api/presidentes/:
+*    get:
+*      summary: Recupera parlamentares presidentes em comissões da Câmara e do Senado.
+*      tags: [Parlamentar (comissões)]
+*      responses:
+*        "200":
+*          description: Recupera informações da lista de parlamentares presidentes de comissões.
+*/
+router.get("/presidentes", (req, res) => {
+  Parlamentar.findAll({
+    attributes: ["id_parlamentar_voz", "casa"],
+    include: [
+      {
+        model: ComposicaoComissoes,
+        attributes: ["cargo"],
+        include: [
+          {
+            model: Comissoes,
+            attributes: ["sigla"],
+            as: "infoComissao",
+            required: false
+          }
+        ],
+        where: {
+          cargo: "Presidente"
+        },
+        as: "parlamentarComissoes",
+        required: true
+      }
+    ]
+  })
+    .then(parlamentares => {
+      res.status(SUCCESS).json(parlamentares);
+    })
+    .catch(err => res.status(BAD_REQUEST).json({ err: err.message }));
 });
 
 module.exports = router;

--- a/server/routes/api/perfil.js
+++ b/server/routes/api/perfil.js
@@ -38,7 +38,36 @@ const attTema = [["id_tema", "idTema"], "tema", "slug"]
 */
 router.get("/lista", (req, res) => {
   PerfilMais.findAll({
-      attributes: attPerfil
+    attributes: attPerfil
+  })
+    .then(parlamentares => res.status(SUCCESS).json(parlamentares))
+    .catch(err => res.status(BAD_REQUEST).json({ err }));
+});
+
+/**
+* @swagger
+* path:
+*  /api/perfil/peso/{id}:
+*    get:
+*      summary: Recupera o peso político para um parlamentar específico.
+*      tags: [Perfil (índices)]
+*      parameters:
+*        - in: path
+*          name: id
+*          schema:
+*            type: integer
+*          required: true
+*          description: Id do parlamentar
+*      responses:
+*        "200":
+*          description: Informações do peso político para um parlamentar específico.
+*/
+router.get("/peso/:id", (req, res) => {
+  PerfilMais.findAll({
+    attributes: attPerfil,
+    where: {
+      id_parlamentar_voz: req.params.id
+    }
   })
     .then(parlamentares => res.status(SUCCESS).json(parlamentares))
     .catch(err => res.status(BAD_REQUEST).json({ err }));


### PR DESCRIPTION
## Mudanças
- Adiciona endpoints para recuperar presidentes de comissões
- Adiciona endpoint para retornar peso político de um parlamentar específico
- Libera acesso de apps à API

Exemplos de consulta:
http://localhost:5000/api/comissoes/presidentes/1160601
http://localhost:5000/api/comissoes/presidentes