### PR TITLE
Remove mock de medianas de patrimônios

### DIFF
--- a/client/src/app/parlamentar/patrimonio/patrimonio.component.ts
+++ b/client/src/app/parlamentar/patrimonio/patrimonio.component.ts
@@ -53,20 +53,18 @@ export class PatrimonioComponent implements OnInit {
   }
 
   handleRequestResponse(resp) {
-    const patrimonio = resp.asset_history || [];
-    this.requestError = false;
-    this.patrimonio = patrimonio;
-    this.temPatrimonio = patrimonio.length > 0;
-    this.isLoading = false;
-    // todo -> buscar da api ao invés de deixar hardcoded
-    this.medianaPatrimonio = [
-      {year: 2006, value: 22711.75},
-      {year: 2008, value: 20000},
-      {year: 2010, value: 30000},
-      {year: 2012, value: 25000},
-      {year: 2014, value: 39338.68},
-      {year: 2016, value: 25000},
-    ];
+    this.perfilPoliticoService.getAssetStats()
+      .pipe(take(1))
+      .subscribe(
+        stats => {
+          const patrimonio = resp.asset_history || [];
+          this.requestError = false;
+          this.patrimonio = patrimonio;
+          this.temPatrimonio = patrimonio.length > 0;
+          this.medianaPatrimonio = stats.mediana_patrimonios;
+          this.isLoading = false;
+        }
+      );
   }
 
   handleRequestError(error) {

--- a/client/src/app/shared/services/perfil-politico.service.ts
+++ b/client/src/app/shared/services/perfil-politico.service.ts
@@ -22,6 +22,9 @@ export class PerfilPoliticoService {
     return this.http.get<EmpresasRelacionadas>(this.url + endpointPath + idPerfilPolitico + '/')
       .pipe(take(1))
       .pipe(map(resp => new EmpresasRelacionadas(resp)));
+  }
 
+  getAssetStats(): Observable<any>{
+    return this.http.get<[]>(this.url + 'asset-stats');
   }
 }


### PR DESCRIPTION
Esta modificação remove um mock que foi feito enquanto o endpoint `https://api-perfilpolitico.serenata.ai/api/asset-stats/` ainda não estava disponibilizado.

Agora, a aba de visualização de dados de patrimônios criada em #446 apresenta as medianas de patrimônios corretamente, de acordo com os dados da API.